### PR TITLE
Add Nexus zkVM to "Users of Stwo" section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -35,3 +35,5 @@ How Cairo is build upon Stwo.
 # Users of Stwo
 
 (other people using stwo)
+
+- [Nexus zkVM](https://github.com/nexus-xyz/nexus-zkvm) ([spec](https://specification.nexus.xyz/))


### PR DESCRIPTION
This PR adds Nexus zkVM to the list of users of stwo.

The newest version of Nexus zkVM is based on stwo. I think it's a relatively big development based on stwo, and it's an example of wide applicability of stwo.